### PR TITLE
fix(pipeline): correct job_url validation that never triggered

### DIFF
--- a/zlm/__init__.py
+++ b/zlm/__init__.py
@@ -316,7 +316,7 @@ class AutoApplyModel:
                 user_data_path = demo_data_path
 
             print("Starting Auto Resume and CV Pipeline")
-            if job_url is None and len(job_url.strip()) == "":
+            if not job_url or not job_url.strip():
                 print("Job URL is required.")
                 return
             


### PR DESCRIPTION
## Summary

Fixes a bug where the job URL validation condition was always `False` due to a logical error, meaning empty/whitespace-only URLs were never caught and the code would crash later.

## Root Cause

```python
# Before — impossible condition: if url IS None, calling .strip() raises AttributeError
if job_url is None and len(job_url.strip()) == :

# After — short-circuit safe: checks None first, then empty/whitespace
if not job_url or not job_url.strip():
```

## Changes
- `zlm/__init__.py`: Fixed job_url guard condition (line 319)

Closes #39