### PR TITLE
fix(api-key): propagate UI key to os.environ and handle empty string

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -144,12 +144,17 @@ try:
             st.toast(":red[Please enter a job posting URL or paste the job description to get started]", icon="⚠️") 
             st.stop()
         
-        if api_key == "" and provider != "Llama":
+        if not api_key and LLM_MAPPING[provider].get("api_env"):
             st.toast(":red[Please enter the API key to get started]", icon="⚠️")
             st.stop()
-        
+
         if file is not None and (url != "" or text != ""):
             download_resume_path = os.path.join(os.path.dirname(__file__), "output")
+
+            # Propagate UI-entered key to os.environ so all downstream
+            # code and SDKs that read env vars directly will find it.
+            if api_key and LLM_MAPPING[provider].get("api_env"):
+                os.environ[LLM_MAPPING[provider]["api_env"]] = api_key
 
             resume_llm = AutoApplyModel(api_key=api_key, provider=provider, model = model, downloads_dir=download_resume_path)
             

--- a/zlm/__init__.py
+++ b/zlm/__init__.py
@@ -60,7 +60,7 @@ class AutoApplyModel:
         self.model = DEFAULT_LLM_MODEL if model is None or model.strip() == "" else model
         self.downloads_dir = utils.get_default_download_folder() if downloads_dir is None or downloads_dir.strip() == "" else downloads_dir
 
-        if api_key is None or api_key.strip() == "os":
+        if not api_key or api_key.strip() == "os":
                 api_env = LLM_MAPPING[self.provider]["api_env"]
                 if api_env != None and api_env.strip() != "":
                     self.api_key = os.environ.get(LLM_MAPPING[self.provider]["api_env"]) 


### PR DESCRIPTION
## Summary

Three fixes for API key handling across the UI and model init.

## Changes

**1. Empty string bypasses env fallback** (`zlm/__init__.py:63`)
`api_key is None` didn't catch empty strings, so `api_key=""` fell through to `self.api_key = ""` and was passed directly to `OpenAI(api_key="")` causing silent auth failures instead of falling back to `os.environ`.
```python
- if api_key is None or api_key.strip() == "os":
+ if not api_key or api_key.strip() == "os":
```

**2. Key never written to `os.environ`** (`web_app.py`)
The UI key was passed to `AutoApplyModel` but never placed in the environment, so downstream SDKs reading `OPENAI_API_KEY`/`GEMINI_API_KEY` directly never saw it.
```python
if api_key and LLM_MAPPING[provider].get("api_env"):
    os.environ[LLM_MAPPING[provider]["api_env"]] = api_key
```

**3. Dead guard — wrong provider name** (`web_app.py:147`)
`provider != "Llama"` was always `True` (no such provider exists). Replaced with `LLM_MAPPING[provider].get("api_env")` so the guard correctly handles any provider that needs no key (e.g. Ollama when re-enabled).

Closes #41