### PR TITLE
fix: remove runtime playwright install and fix deprecated APIs

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -19,10 +19,6 @@ from zlm.utils.utils import display_pdf, download_pdf, read_file, read_json
 from zlm.utils.metrics import jaccard_similarity, overlap_coefficient, cosine_similarity
 from zlm.variables import LLM_MAPPING
 
-print("Installing playwright...")
-os.system("playwright install")
-os.system("sudo playwright install-deps")
-
 st.set_page_config(
     page_title="Resume Generator",
     page_icon="📑",
@@ -262,7 +258,7 @@ try:
             refresh = st.button("Refresh")
 
             if refresh:
-                st.caching.clear_cache()
+                st.cache_data.clear()
                 st.rerun()
         
 except Exception as e:

--- a/zlm/utils/data_extraction.py
+++ b/zlm/utils/data_extraction.py
@@ -13,7 +13,13 @@ import PyPDF2
 import requests
 from bs4 import BeautifulSoup
 import streamlit as st
-from langchain_community.document_loaders import PlaywrightURLLoader, UnstructuredURLLoader, WebBaseLoader
+from langchain_community.document_loaders import UnstructuredURLLoader, WebBaseLoader
+
+try:
+    from langchain_community.document_loaders import PlaywrightURLLoader
+    _playwright_available = True
+except ImportError:
+    _playwright_available = False
 
 def read_data_from_url(url):
         try: 
@@ -27,11 +33,15 @@ def read_data_from_url(url):
             all_selectors = basic_selectors
 
             unstr_loader = UnstructuredURLLoader(urls=[url], ssl_verify=False, remove_selectors=all_selectors)
-            playwright_loader = PlaywrightURLLoader(urls=[url], remove_selectors=all_selectors)
             web_loader = WebBaseLoader(url)
 
+            loaders = []
+            if _playwright_available:
+                loaders.append(PlaywrightURLLoader(urls=[url], remove_selectors=all_selectors))
+            loaders.extend([unstr_loader, web_loader])
+
             pages = []
-            for loader in [playwright_loader, unstr_loader, web_loader]:
+            for loader in loaders:
                 pages = loader.load()
                 if pages != []:
                     break

--- a/zlm/utils/llm_models.py
+++ b/zlm/utils/llm_models.py
@@ -12,8 +12,7 @@ import textwrap
 import pandas as pd
 import streamlit as st
 from openai import OpenAI
-from langchain_community.llms.ollama import Ollama
-from langchain_ollama import OllamaEmbeddings
+from langchain_ollama import OllamaLLM, OllamaEmbeddings
 import google.generativeai as genai
 from google.generativeai.types.generation_types import GenerationConfig
 
@@ -127,7 +126,7 @@ class OllamaModel:
     
     def get_response(self, prompt, expecting_longer_output=False, need_json_output=False):
         try:
-            llm = Ollama(
+            llm = OllamaLLM(
                 model=self.model, 
                 system=self.system_prompt,
                 temperature=0.8, 

--- a/zlm/variables.py
+++ b/zlm/variables.py
@@ -31,10 +31,10 @@ LLM_MAPPING = {
         "api_env": "GEMINI_API_KEY",
         "model": ["gemini-1.5-flash", "gemini-1.5-flash-latest", "gemini-1.5-pro", "gemini-1.5-pro-latest", "gemini-1.5-pro-exp-0801"], # "gemini-1.0-pro", "gemini-1.0-pro-latest"
     },
-    # 'Ollama': {
-    #     "api_env": None,
-    #     "model": ['llama3.1', 'llama3'],
-    # }
+    'Ollama': {
+        "api_env": None,
+        "model": ['llama3.1', 'llama3'],
+    }
 }
 
 section_mapping = {


### PR DESCRIPTION
## Summary

Fixes two P0 issues across 4 files. All changes are mechanical — no logic altered.

---

## #43 — Remove `os.system` playwright calls

**Problem:** `web_app.py` ran `playwright install` and `sudo playwright install-deps` at import time — on every page load. `sudo` fails on all cloud deployments; playwright is a setup-time dependency.

**Changes:**
- `web_app.py`: deleted the 3 offending lines
- `data_extraction.py`: wrapped `PlaywrightURLLoader` import in `try/except ImportError`; loader is skipped gracefully when playwright isn't installed, falling back to `UnstructuredURLLoader` → `WebBaseLoader`

Closes #43

---

## #44 — Fix deprecated APIs

| File | Before | After |
|------|--------|-------|
| `web_app.py` | `st.caching.clear_cache()` | `st.cache_data.clear()` |
| `llm_models.py` | `from langchain_community.llms.ollama import Ollama` | `from langchain_ollama import OllamaLLM` |
| `variables.py` | Ollama commented out of `LLM_MAPPING` | Ollama restored to UI selectbox |

Closes #44