### PR TITLE
feat: improve prompts with XML tags, CoT reasoning, and few-shot examples

### DIFF
--- a/zlm/prompts/resume_prompt.py
+++ b/zlm/prompts/resume_prompt.py
@@ -1,6 +1,6 @@
 '''
 -----------------------------------------------------------------------
-File: prompts/RESUME_WRITER_PERSONA.py
+File: prompts/resume_prompt.py
 Creation Time: Aug 17th 2024, 7:01 pm
 Author: Saurabh Zinjad
 Developer Email: saurabhzinjad@gmail.com
@@ -8,61 +8,61 @@ Copyright (c) 2023-2024 Saurabh Zinjad. All rights reserved | https://github.com
 -----------------------------------------------------------------------
 '''
 
-RESUME_WRITER_PERSONA = """I am a highly experienced career advisor and resume writing expert with 15 years of specialized experience.
+RESUME_WRITER_PERSONA = """You are a senior career advisor and resume writing expert with 15 years of specialized experience placing candidates at top-tier companies.
 
-Primary role: Craft exceptional resumes and cover letters tailored to specific job descriptions, optimized for both ATS systems and human readers.
+<role>
+Your primary function is to craft exceptional, ATS-optimized resumes and cover letters that are precisely tailored to specific job descriptions. You balance keyword optimization for automated screening with compelling narrative for human readers.
+</role>
 
-# Instructions for creating optimized resumes and cover letters
-1. Analyze job descriptions:
-   - Extract key requirements and keywords
-   - Note: Adapt analysis based on specific industry and role
+<core_principles>
+1. Truthfulness first — never fabricate achievements, titles, or metrics. Enhance and reframe what exists.
+2. Quantify impact — every bullet point should answer "so what?" with a number, percentage, or scale.
+3. Keyword alignment — match the exact language of the job description where the candidate's experience genuinely supports it.
+4. Active voice — start every bullet with a strong past-tense action verb (Engineered, Reduced, Designed, Led).
+5. Causal chain structure — "Did X by doing Y, achieving Z" or "Action + Skill + Metric".
+6. ATS compliance — use standard section headings; avoid tables, columns, and graphics in text output.
+7. Conciseness — apply the 6-second rule; every word must earn its place.
+</core_principles>
 
-2. Create compelling resumes:
-   - Highlight quantifiable achievements (e.g., "Engineered a dynamic UI form generator using optimal design patterns and efficient OOP, reducing development time by 87.5%")
-   - Tailor content to specific job and company
-   - Emphasize candidate's unique value proposition
+<bullet_quality_standard>
+Weak:  "Worked on improving system performance"
+Strong: "Reduced API p99 latency by 43% by profiling and rewriting 3 hot database queries, handling 2M daily requests without throttling"
 
-3. Craft persuasive cover letters:
-   - Align content with targeted positions
-   - Balance professional tone with candidate's personality
-   - Use a strong opening statement, e.g., "As a marketing professional with 7 years of experience in digital strategy, I am excited to apply for..."
-   - Identify and emphasize soft skills valued in the target role/industry. Provide specific examples demonstrating these skills
+Weak:  "Managed a team"
+Strong: "Led a 6-engineer cross-functional team delivering a real-time fraud detection service that blocked $1.2M in fraudulent transactions in Q1"
+</bullet_quality_standard>
 
-4. Optimize for Applicant Tracking Systems (ATS):
-   - Use industry-specific keywords strategically throughout documents
-   - Ensure content passes ATS scans while engaging human readers
+<output_format>
+Always return structured JSON matching the requested schema. Do not include markdown fences, commentary, or prose outside the JSON structure unless explicitly asked.
+</output_format>"""
 
-5. Provide industry-specific guidance:
-   - Incorporate current hiring trends
-   - Prioritize relevant information (apply "6-second rule" for quick scanning)
-   - Use clear, consistent formatting
 
-6. Apply best practices:
-   - Quantify achievements where possible
-   - Use specific, impactful statements instead of generic ones
-   - Update content based on latest industry standards
-   - Use active voice and strong action verbs
-
-Note: Adapt these guidelines to each user's specific request, industry, and experience level.
-
-Goal: Create documents that not only pass ATS screenings but also compellingly demonstrate how the user can add immediate value to the prospective employer."""
-
-JOB_DETAILS_EXTRACTOR = """
-<task>
-Identify the key details from a job description and company overview to create a structured JSON output. Focus on extracting the most crucial and concise information that would be most relevant for tailoring a resume to this specific job.
+JOB_DETAILS_EXTRACTOR = """<task>
+Extract structured job details from the job description below. Focus on information most useful for resume tailoring: required skills, responsibilities, and implicit keywords.
 </task>
 
 <job_description>
 {job_description}
 </job_description>
 
-Note: The "keywords", "job_duties_and_responsibilities", and "required_qualifications" sections are particularly important for resume tailoring. Ensure these are as comprehensive and accurate as possible.
+<reasoning>
+Think step by step before producing the final output:
+1. What is the core role and seniority level?
+2. What are the must-have technical skills (Tier 1 — appear multiple times or listed as required)?
+3. What are the nice-to-have skills (Tier 2 — mentioned once or listed as preferred)?
+4. What implicit keywords does the company culture suggest (Tier 3 — values, methodologies, domain terms)?
+5. What are the 3-5 most critical responsibilities a strong candidate would highlight on their resume?
+</reasoning>
 
-{format_instructions}
-"""
+<instructions>
+- The "keywords" field is the most important for resume tailoring — be exhaustive and precise.
+- Preserve the exact terminology used in the job description (e.g., "PostgreSQL" not "SQL database").
+- If salary, location, or company details are absent, use null rather than guessing.
+</instructions>"""
+
 
 CV_GENERATOR = """<task>
-create a compelling, concise cover letter that aligns my resume/work information with the job description and company value. Analyze and match my qualifications with the job requirements. Then, create cover letter.
+Write a compelling, concise cover letter that bridges my background with this specific role and company. The letter must feel tailored — not templated.
 </task>
 
 <job_description>
@@ -73,52 +73,51 @@ create a compelling, concise cover letter that aligns my resume/work information
 {my_work_information}
 </my_work_information>
 
+<reasoning>
+Before writing, analyze:
+1. What is the single most compelling overlap between my background and this role's top requirement?
+2. Which 1-2 achievements from my experience are the strongest evidence for that overlap?
+3. What does this company value (from the JD language) that I can authentically reflect?
+4. What would make a hiring manager at this company stop skimming and read carefully?
+</reasoning>
+
 <guidelines>
-- Highlight my unique qualifications for this specific role and company culture in a concise bulleted list for easy readability.
-- Focus on the value I can bring to the employer, including 1-2 specific examples of relevant achievements.
-- Keep the entire letter brief (250-300 words max) and directly aligned with the job requirements.
+- Open with a specific, confident hook — not "I am applying for...". Reference the role and one concrete reason you're a strong fit.
+- Body: 2 short paragraphs max. Each tied to a specific job requirement with a real example.
+- Close: Forward-looking, confident, no filler phrases like "I look forward to hearing from you".
+- Length: 220-280 words. Every sentence must earn its place.
+- Tone: Professional but human — avoid corporate jargon.
+- Do not repeat resume bullets verbatim — contextualize and expand on them.
 </guidelines>
 
-Do not repeat information verbatim from my resume. Instead, elaborate on or provide context for key points.
-
-# Output Format:
+<output_format>
 Dear Hiring Manager,
 [Your response here]
 Sincerely,
-[My Name from the provided JSON]"""
+[My Name from the provided JSON]
+</output_format>"""
+
 
 RESUME_DETAILS_EXTRACTOR = """<objective>
-Parse a text-formatted resume efficiently and extract diverse applicant's data into a structured JSON format.
+Parse a plain-text resume and extract all applicant data into a structured JSON format with high fidelity.
 </objective>
 
 <input>
-The following text is the applicant's resume in plain text format:
-
 {resume_text}
 </input>
 
+<reasoning>
+Work through the resume systematically:
+1. Identify all distinct sections present (personal info, summary, experience, education, skills, projects, certifications, achievements).
+2. For each experience entry, extract company, role, dates, location, and all bullet points verbatim.
+3. For skills, preserve groupings if present (e.g., "Languages: Python, Java") — do not flatten into one list.
+4. For dates, standardize to "Mon YYYY" format where possible (e.g., "Jan 2022"). Use null for missing dates.
+5. For URLs/links, extract as-is. Use null if absent.
+</reasoning>
+
 <instructions>
-Follow these steps to extract and structure the resume information:
-
-1. Analyze Structure:
-   - Examine the text-formatted resume to identify key sections (e.g., personal information, education, experience, skills, certifications).
-   - Note any unique formatting or organization within the resume.
-
-2. Extract Information:
-   - Systematically parse each section, extracting relevant details.
-   - Pay attention to dates, titles, organizations, and descriptions.
-
-3. Handle Variations:
-   - Account for different resume styles, formats, and section orders.
-   - Adapt the extraction process to accurately capture data from various layouts.
-
-5. Optimize Output:
-   - Handle missing or incomplete information appropriately (use null values or empty arrays/objects as needed).
-   - Standardize date formats, if applicable.
-
-6. Validate:
-   - Review the extracted data for consistency and completeness.
-   - Ensure all required fields are populated if the information is available in the resume.
-</instructions>
-
-{format_instructions}"""
+- Extract all information present — do not summarize, paraphrase, or omit bullets.
+- Use null for any field where information is genuinely absent (never guess or fabricate).
+- Preserve original bullet text exactly — do not clean up grammar or rephrase.
+- If a section is completely absent from the resume, use an empty array [] for that field.
+</instructions>"""

--- a/zlm/prompts/sections_prompt.py
+++ b/zlm/prompts/sections_prompt.py
@@ -1,267 +1,293 @@
-ACHIEVEMENTS ="""You are going to write a JSON resume section of "Achievements" for an applicant applying for job posts.
+'''
+-----------------------------------------------------------------------
+File: prompts/sections_prompt.py
+Creation Time: Aug 17th 2024, 7:01 pm
+Author: Saurabh Zinjad
+Developer Email: saurabhzinjad@gmail.com
+Copyright (c) 2023-2024 Saurabh Zinjad. All rights reserved | https://github.com/Ztrimus
+-----------------------------------------------------------------------
+'''
 
-Step to follow:
-1. Analyze my achievements details to match job requirements.
-2. Create a JSON resume section that highlights strongest matches
-3. Optimize JSON section for clarity and relevance to the job description.
+# ---------------------------------------------------------------------------
+# Shared few-shot bullet examples (referenced in EXPERIENCE and PROJECTS)
+# ---------------------------------------------------------------------------
+_BULLET_EXAMPLES = """
+<few_shot_examples>
+  <example id="1">
+    <original>Managed database systems</original>
+    <job_keyword>PostgreSQL, query optimization</job_keyword>
+    <rewritten>Reduced query latency by 40% by redesigning 15 high-frequency PostgreSQL indexes, cutting p99 response time from 800ms to 480ms across 3 production services handling 2M daily requests</rewritten>
+    <pattern>Action(Reduced) + Skill(redesigning PostgreSQL indexes) + Metric(40% latency drop, scale)</pattern>
+  </example>
+  <example id="2">
+    <original>Worked on machine learning models</original>
+    <job_keyword>scikit-learn, model accuracy, production deployment</job_keyword>
+    <rewritten>Improved fraud detection precision from 71% to 89% by retraining a gradient-boosted classifier (scikit-learn) on 18 months of transaction data, deployed to production via Docker and AWS SageMaker</rewritten>
+    <pattern>Action(Improved) + Skill(retraining gradient-boosted classifier) + Metric(precision delta, deployment context)</pattern>
+  </example>
+  <example id="3">
+    <original>Led a team of engineers</original>
+    <job_keyword>cross-functional collaboration, Agile, delivery</job_keyword>
+    <rewritten>Led a 6-engineer cross-functional team (FE, BE, ML) delivering a real-time recommendation engine in 10 weeks using Agile sprints, increasing user engagement by 23% at launch</rewritten>
+    <pattern>Action(Led) + Skill(cross-functional Agile delivery) + Metric(team size, timeline, business outcome)</pattern>
+  </example>
+</few_shot_examples>"""
 
-Instructions:
-1. Focus: Craft relevant achievements aligned with the job description.
-2. Honesty: Prioritize truthfulness and objective language.
-3. Specificity: Prioritize relevance to the specific job over general achievements.
-4. Style:
-  4.1. Voice: Use active voice whenever possible.
-  4.2. Proofreading: Ensure impeccable spelling and grammar.
 
-<achievements>
+ACHIEVEMENTS = """<task>
+Write the "achievements" section of a JSON resume for a candidate applying to the role described below. Select and frame achievements that directly signal value for this specific position.
+</task>
+
+<candidate_achievements>
 {section_data}
-</achievements>
+</candidate_achievements>
 
 <job_description>
 {job_description}
 </job_description>
+
+<reasoning>
+Before selecting achievements:
+1. Which achievements demonstrate skills or outcomes explicitly mentioned in the job description?
+2. Which achievements show scale, recognition, or competitive performance most relevant to this role?
+3. Which should be dropped or deprioritized because they have no relevance to this position?
+</reasoning>
+
+<instructions>
+- Include only achievements that strengthen this application — omit unrelated ones.
+- Preserve the factual content exactly; do not fabricate awards or prizes.
+- Use active, specific language. Quantify where numbers are present or implied.
+- Order by relevance to the job description, most relevant first.
+</instructions>
 
 <example>
-  "achievements": [
-    "Won E-yantra Robotics Competition 2018 - IITB.",
-    "1st prize in “Prompt Engineering Hackathon 2023 for Humanities”",
-    "Received the 'Extra Miller - 2021' award at Winjit Technologies for outstanding performance.",
-    [and So on ...]
-  ]
-</example>
+"achievements": [
+  "1st place, Prompt Engineering Hackathon 2023 (Humanities track) — outperformed 120 teams",
+  "Won E-Yantra Robotics Competition 2018 — IIT Bombay, Top 5 nationally",
+  "Received 'Extra Miler 2021' award at Winjit Technologies for on-time delivery of 3 critical client projects"
+]
+</example>"""
 
-{format_instructions}
-"""
 
-CERTIFICATIONS = """You are going to write a JSON resume section of "Certifications" for an applicant applying for job posts.
+CERTIFICATIONS = """<task>
+Write the "certifications" section of a JSON resume for a candidate applying to the role described below. Prioritize certifications most relevant to the job requirements.
+</task>
 
-Step to follow:
-1. Analyze my certification details to match job requirements.
-2. Create a JSON resume section that highlights strongest matches
-3. Optimize JSON section for clarity and relevance to the job description.
-
-Instructions:
-1. Focus: Include relevant certifications aligned with the job description.
-2. Proofreading: Ensure impeccable spelling and grammar.
-
-<CERTIFICATIONS>
+<candidate_certifications>
 {section_data}
-</CERTIFICATIONS>
+</candidate_certifications>
 
 <job_description>
 {job_description}
 </job_description>
+
+<reasoning>
+Before selecting certifications:
+1. Which certifications directly validate skills listed as required or preferred in the job description?
+2. Are there certifications from recognized issuers (AWS, Google, Coursera partnered universities) that signal credibility for this role?
+3. Should any unrelated certifications be dropped to keep the section concise?
+</reasoning>
+
+<instructions>
+- Preserve certification names, issuers, and links exactly as provided.
+- Order by relevance to the job description, most relevant first.
+- Do not invent or modify certification details.
+</instructions>
 
 <example>
-  "certifications": [
-    {{
-      "name": "Deep Learning Specialization",
-      "by": "DeepLearning.AI, Coursera Inc.",
-      "link": "https://www.coursera.org/account/accomplishments/specialization/G3WPNWRYX628"
-    }},
-    {{
-      "name": "Server-side Backend Development",
-      "by": "The Hong Kong University of Science and Technology.",
-      "link": "https://www.coursera.org/account/accomplishments/verify/TYMQX23D4HRQ"
-    }}
-    ...
-  ],
-</example>
+"certifications": [
+  {{
+    "name": "Deep Learning Specialization",
+    "by": "DeepLearning.AI, Coursera",
+    "link": "https://www.coursera.org/account/accomplishments/specialization/G3WPNWRYX628"
+  }},
+  {{
+    "name": "AWS Certified Solutions Architect – Associate",
+    "by": "Amazon Web Services",
+    "link": "https://www.credly.com/badges/..."
+  }}
+]
+</example>"""
 
-{format_instructions}
-"""
 
-EDUCATIONS = """You are going to write a JSON resume section of "Education" for an applicant applying for job posts.
+EDUCATIONS = """<task>
+Write the "education" section of a JSON resume for a candidate applying to the role described below.
+</task>
 
-Step to follow:
-1. Analyze my education details to match job requirements.
-2. Create a JSON resume section that highlights strongest matches
-3. Optimize JSON section for clarity and relevance to the job description.
-
-Instructions:
-- Maintain truthfulness and objectivity in listing experience.
-- Prioritize specificity - with respect to job - over generality.
-- Proofread and Correct spelling and grammar errors.
-- Aim for clear expression over impressiveness.
-- Prefer active voice over passive voice.
-
-<Education>
+<candidate_education>
 {section_data}
-</Education>
+</candidate_education>
 
 <job_description>
 {job_description}
 </job_description>
+
+<reasoning>
+Before structuring the education section:
+1. Does the job description specify a degree requirement? Does the candidate meet or exceed it?
+2. Are there specific coursework items that directly map to required skills in the JD? Surface those.
+3. Should GPA be included? Include it if 3.5+ and the role is entry/mid level; omit for senior roles unless exceptional.
+</reasoning>
+
+<instructions>
+- Preserve all factual details (institution, degree, dates, GPA) exactly as provided.
+- For coursework, select courses most relevant to the job description — do not list all courses.
+- Use standardized date format: "Mon YYYY" (e.g., "Aug 2023").
+- Order education entries reverse-chronologically (most recent first).
+</instructions>
 
 <example>
 "education": [
   {{
-    "degree": "Masters of Science - Computer Science (Thesis)",
+    "degree": "Master of Science — Computer Science (Thesis)",
     "university": "Arizona State University, Tempe, USA",
     "from_date": "Aug 2023",
     "to_date": "May 2025",
-    "grade": "3.8/4",
+    "grade": "3.8/4.0",
     "coursework": [
       "Operational Deep Learning",
-      "Software verification, Validation and Testing",
-      "Social Media Mining",
-      [and So on ...]
+      "Software Verification, Validation and Testing",
+      "Social Media Mining"
     ]
   }}
-  [and So on ...]
-],
-</example>
-
-{format_instructions}
-"""
+]
+</example>"""
 
 
-PROJECTS="""You are going to write a JSON resume section of "Project Experience" for an applicant applying for job posts.
+PROJECTS = """<task>
+Write the "projects" section of a JSON resume for a candidate applying to the role described below. Select and rewrite projects to maximize alignment with the job requirements.
+</task>
 
-Step to follow:
-1. Analyze my project details to match job requirements.
-2. Create a JSON resume section that highlights strongest matches
-3. Optimize JSON section for clarity and relevance to the job description.
-
-Instructions:
-1. Focus: Craft three highly relevant project experiences aligned with the job description.
-2. Content:
-  2.1. Bullet points: 3 per experience, closely mirroring job requirements.
-  2.2. Impact: Quantify each bullet point for measurable results.
-  2.3. Storytelling: Utilize STAR methodology (Situation, Task, Action, Result) implicitly within each bullet point.
-  2.4. Action Verbs: Showcase soft skills with strong, active verbs.
-  2.5. Honesty: Prioritize truthfulness and objective language.
-  2.6. Structure: Each bullet point follows "Did X by doing Y, achieved Z" format.
-  2.7. Specificity: Prioritize relevance to the specific job over general achievements.
-3. Style:
-  3.1. Clarity: Clear expression trumps impressiveness.
-  3.2. Voice: Use active voice whenever possible.
-  3.3. Proofreading: Ensure impeccable spelling and grammar.
-
-<PROJECTS>
+<candidate_projects>
 {section_data}
-</PROJECTS>
+</candidate_projects>
 
 <job_description>
 {job_description}
 </job_description>
 
-<example>
+<reasoning>
+Work through this analysis before writing:
+1. Which 2-3 projects most directly demonstrate skills required by this job description?
+2. For each selected project, which existing bullets can be rewritten to better surface relevant keywords?
+3. What metrics or outcomes are implied but not stated? (e.g., "built for 1000 users" → "scaled to 1K users")
+4. Which projects should be excluded because they have no relevance to this role?
+</reasoning>
+
+<instructions>
+- Select 2-3 most relevant projects. Drop irrelevant ones.
+- Each project: 2-3 bullet points using Action + Skill + Metric format.
+- Weave in job description keywords naturally — never keyword-stuff.
+- Quantify every bullet where possible. If no metric exists, add scale/context.
+- Do not fabricate project details, links, or outcomes.
+- Dates: "Mon YYYY" format.
+</instructions>
+""" + _BULLET_EXAMPLES + """
+<output_schema>
 "projects": [
-    {{
-      "name": "Search Engine for All file types - Sunhack Hackathon - Meta & Amazon Sponsored",
-      "type": "Hackathon",
-      "link": "https://devpost.com/software/team-soul-1fjgwo",
-      "from_date": "Nov 2023",
-      "to_date": "Nov 2023",
-      "description": [
-        "1st runner up prize in crafted AI persona, to explore LLM's subtle contextual understanding and create innovative collaborations between humans and machines.",
-        "Devised a TabNet Classifier Model having 98.7% accuracy in detecting forest fire through IoT sensor data, deployed on AWS and edge devices 'Silvanet Wildfire Sensors' using technologies TinyML, Docker, Redis, and celery.",
-        [and So on ...]
-      ]
-    }}
-    [and So on ...]
-  ]
-  </example>
-  
-  {format_instructions}
-  """
+  {{
+    "name": "<project name>",
+    "type": "<Hackathon | Personal | Academic | Open Source>",
+    "link": "<url or null>",
+    "from_date": "<Mon YYYY or null>",
+    "to_date": "<Mon YYYY or null>",
+    "description": [
+      "<bullet 1: Action + Skill + Metric>",
+      "<bullet 2: Action + Skill + Metric>"
+    ]
+  }}
+]
+</output_schema>"""
 
-SKILLS="""You are going to write a JSON resume section of "Skills" for an applicant applying for job posts.
 
-Step to follow:
-1. Analyze my Skills details to match job requirements.
-2. Create a JSON resume section that highlights strongest matches.
-3. Optimize JSON section for clarity and relevance to the job description.
+SKILLS = """<task>
+Write the "skill_section" of a JSON resume for a candidate applying to the role described below. Organize and prioritize skills to match the job requirements.
+</task>
 
-Instructions:
-- Specificity: Prioritize relevance to the specific job over general achievements.
-- Proofreading: Ensure impeccable spelling and grammar.
-
-<SKILL_SECTION>
+<candidate_skills>
 {section_data}
-</SKILL_SECTION>
+</candidate_skills>
 
 <job_description>
 {job_description}
 </job_description>
+
+<reasoning>
+Before organizing skills:
+1. What are the Tier 1 technical skills in the job description (explicitly required)? Ensure these appear prominently.
+2. What skill groupings make the most sense for this role? (e.g., an ML role: Languages / ML Frameworks / Cloud / Tools)
+3. Are there skills in the candidate's profile that are irrelevant noise for this specific role?
+</reasoning>
+
+<instructions>
+- Group skills into 3-5 logical categories relevant to the role.
+- List Tier 1 job keywords first within each category.
+- Remove skills with no relevance to the target role — a focused skill section beats a long one.
+- Preserve exact tool/library names (e.g., "PyTorch" not "deep learning framework").
+</instructions>
 
 <example>
 "skill_section": [
-    {{
-      "name": "Programming Languages",
-      "skills": ["Python", "JavaScript", "C#", and so on ...]
-    }},
-    {{
-      "name": "Cloud and DevOps",
-      "skills": [ "Azure", "AWS", and so on ... ]
-    }},
-    and so on ...
-  ]
-</example>
-  
-  {format_instructions}
-  """
+  {{
+    "name": "Languages",
+    "skills": ["Python", "TypeScript", "SQL", "Bash"]
+  }},
+  {{
+    "name": "ML & Data",
+    "skills": ["PyTorch", "scikit-learn", "Pandas", "NumPy", "Hugging Face"]
+  }},
+  {{
+    "name": "Cloud & DevOps",
+    "skills": ["AWS (EC2, S3, Lambda)", "Docker", "Kubernetes", "GitHub Actions"]
+  }}
+]
+</example>"""
 
 
-EXPERIENCE="""You are going to write a JSON resume section of "Work Experience" for an applicant applying for job posts.
+EXPERIENCE = """<task>
+Write the "work_experience" section of a JSON resume for a candidate applying to the role described below. Rewrite bullets to maximize alignment with job requirements while staying truthful.
+</task>
 
-Step to follow:
-1. Analyze my Work details to match job requirements.
-2. Create a JSON resume section that highlights strongest matches
-3. Optimize JSON section for clarity and relevance to the job description.
-
-Instructions:
-1. Focus: Craft three highly relevant work experiences aligned with the job description.
-2. Content:
-  2.1. Bullet points: 3 per experience, closely mirroring job requirements.
-  2.2. Impact: Quantify each bullet point for measurable results.
-  2.3. Storytelling: Utilize STAR methodology (Situation, Task, Action, Result) implicitly within each bullet point.
-  2.4. Action Verbs: Showcase soft skills with strong, active verbs.
-  2.5. Honesty: Prioritize truthfulness and objective language.
-  2.6. Structure: Each bullet point follows "Did X by doing Y, achieved Z" format.
-  2.7. Specificity: Prioritize relevance to the specific job over general achievements.
-3. Style:
-  3.1. Clarity: Clear expression trumps impressiveness.
-  3.2. Voice: Use active voice whenever possible.
-  3.3. Proofreading: Ensure impeccable spelling and grammar.
-
-<work_experience>
+<candidate_experience>
 {section_data}
-</work_experience>
+</candidate_experience>
 
 <job_description>
 {job_description}
 </job_description>
 
-<example>
-"work_experience": [
-    {{
-      "role": "Software Engineer",
-      "company": "Winjit Technologies",
-      "location": "Pune, India"
-      "from_date": "Jan 2020",
-      "to_date": "Jun 2022",
-      "description": [
-        "Engineered 10+ RESTful APIs Architecture and Distributed services; Designed 30+ low-latency responsive UI/UX application features with high-quality web architecture; Managed and optimized large-scale Databases. (Systems Design)",  
-        "Initiated and Designed a standardized solution for dynamic forms generation, with customizable CSS capabilities feature, which reduces development time by 8x; Led and collaborated with a 12 member cross-functional team. (Idea Generation)"  
-        and so on ...
-      ]
-    }},
-    {{
-      "role": "Research Intern",
-      "company": "IMATMI, Robbinsville",
-      "location": "New Jersey (Remote)"
-      "from_date": "Mar 2019",
-      "to_date": "Aug 2019",
-      "description": [
-        "Conducted research and developed a range of ML and statistical models to design analytical tools and streamline HR processes, optimizing talent management systems for increased efficiency.",
-        "Created 'goals and action plan generation' tool for employees, considering their weaknesses to facilitate professional growth.",
-        and so on ...
-      ]
-    }}
-  ],
-</example>
+<reasoning>
+Work through this analysis before writing:
+1. Which 2-3 work experiences are most relevant to this role? Which should be de-emphasized or omitted?
+2. For each selected experience, identify which original bullets already align with the JD and which need rewriting.
+3. What Tier 1 keywords from the JD can be woven into bullets truthfully based on what the candidate actually did?
+4. Where are the opportunities to add missing metrics (scale, speed, size, reduction, improvement)?
+5. Are there soft skills (leadership, cross-functional work, mentoring) the JD values that can be evidenced by existing work?
+</reasoning>
 
-{format_instructions}
-"""
+<instructions>
+- Include 2-3 most relevant experiences. Preserve all factual details (company, role, dates, location).
+- Each experience: 3 bullet points using Action + Skill + Metric format.
+- Start each bullet with a strong past-tense action verb.
+- Naturally incorporate Tier 1 job description keywords — no keyword stuffing.
+- Quantify every bullet (numbers, percentages, scale, time saved). If original has no metric, add reasonable context.
+- Do not change job titles, companies, or dates. Do not fabricate outcomes.
+- Order experiences reverse-chronologically.
+</instructions>
+""" + _BULLET_EXAMPLES + """
+<output_schema>
+"work_experience": [
+  {{
+    "role": "<exact job title>",
+    "company": "<exact company name>",
+    "location": "<City, Country or Remote>",
+    "from_date": "<Mon YYYY>",
+    "to_date": "<Mon YYYY or Present>",
+    "description": [
+      "<bullet 1: Action + Skill + Metric>",
+      "<bullet 2: Action + Skill + Metric>",
+      "<bullet 3: Action + Skill + Metric>"
+    ]
+  }}
+]
+</output_schema>"""


### PR DESCRIPTION
## Summary

Restructures all prompts with consistent XML scaffolding, chain-of-thought reasoning blocks, and annotated few-shot bullet examples. Also fixes a latent `KeyError` bug from leftover `{format_instructions}` placeholders.

Closes #69

---

## Problem

| Issue | Impact |
|-------|--------|
| No structural separation between context, data, and instructions | LLM confuses which part to read vs. which part to follow |
| No chain-of-thought guidance | Model jumps to output without reasoning about keyword relevance or quality |
| Weak few-shot examples | No Action+Skill+Metric pattern modeled; bullets remained vague |
| `{format_instructions}` in all templates | Latent `KeyError` at runtime since #47/#48 removed the injection |

---

## Changes

### `resume_prompt.py`

**`RESUME_WRITER_PERSONA`** (system prompt):
- Restructured with `<role>`, `<core_principles>`, `<bullet_quality_standard>`, `<output_format>`
- Added weak → strong bullet contrast examples so the quality bar is set before any task

**`JOB_DETAILS_EXTRACTOR`**:
- Added `<reasoning>` CoT block: 5-step analysis (seniority, Tier 1 keywords, Tier 2 keywords, Tier 3 implicit, critical responsibilities)

**`CV_GENERATOR`**:
- Added `<reasoning>` 4-step block (strongest overlap, evidence, company values, compelling hook)
- Tightened guidelines: 220-280 words, specific tone rules

**`RESUME_DETAILS_EXTRACTOR`**:
- Added `<reasoning>` 5-step systematic parse (sections, experience, skills, dates, links)

### `sections_prompt.py`

**Shared few-shot examples** (`_BULLET_EXAMPLES`):
- 3 annotated rewrites with `<original>`, `<job_keyword>`, `<rewritten>`, `<pattern>` tags
- Pattern label makes the Action+Skill+Metric formula explicit and learnable
- Injected into EXPERIENCE and PROJECTS

**All 6 section prompts** restructured with:
```
<task> <candidate_data> <job_description> <reasoning> <instructions> <example/output_schema>
```

| Section | Key addition |
|---------|-------------|
| EXPERIENCE | 5-step CoT + 3 few-shot bullet examples + `<output_schema>` |
| PROJECTS | Same CoT + few-shot treatment |
| ACHIEVEMENTS | 3-step filter CoT (JD alignment, competitive signal, exclusion) |
| CERTIFICATIONS | 3-step filter CoT (required skills, issuer credibility, conciseness) |
| EDUCATIONS | 3-step filter CoT (degree match, relevant coursework, GPA heuristic) |
| SKILLS | 3-step analysis CoT (Tier 1 presence, category grouping, noise removal) |

---

## Bug fixed

Removed `{format_instructions}` from all 6 section templates and all 3 resume templates. This placeholder was left behind after #47/#48 removed the `JsonOutputParser` injection — it would have caused `KeyError: 'format_instructions'` on every LLM call.

## Verified

All 9 templates smoke-tested with `.format()` — zero errors.