### PR TITLE
feat: implement 3-tier keyword extraction from job descriptions

### DIFF
--- a/zlm/prompts/resume_prompt.py
+++ b/zlm/prompts/resume_prompt.py
@@ -55,8 +55,13 @@ Think step by step before producing the final output:
 </reasoning>
 
 <instructions>
-- The "keywords" field is the most important for resume tailoring — be exhaustive and precise.
-- Preserve the exact terminology used in the job description (e.g., "PostgreSQL" not "SQL database").
+- Populate both `keywords` (flat exhaustive list) AND `keyword_tiers` (tiered classification):
+    • Tier 1 (tier1_must_have): Hard skills, tools, technologies, certifications explicitly required.
+      Use the exact terminology from the JD. Aim for 4-5 items.
+    • Tier 2 (tier2_high_priority): Soft skills, methodologies, experience types listed as preferred.
+      Aim for 3-4 items.
+    • Tier 3 (tier3_bonus): Culture language, nice-to-haves, domain jargon. Aim for 2-3 items.
+- Preserve exact JD terminology in all keyword fields (e.g., "PostgreSQL" not "SQL database").
 - If salary, location, or company details are absent, use null rather than guessing.
 </instructions>"""
 

--- a/zlm/prompts/sections_prompt.py
+++ b/zlm/prompts/sections_prompt.py
@@ -168,10 +168,13 @@ Write the "projects" section of a JSON resume for a candidate applying to the ro
 
 <reasoning>
 Work through this analysis before writing:
-1. Which 2-3 projects most directly demonstrate skills required by this job description?
-2. For each selected project, which existing bullets can be rewritten to better surface relevant keywords?
-3. What metrics or outcomes are implied but not stated? (e.g., "built for 1000 users" → "scaled to 1K users")
-4. Which projects should be excluded because they have no relevance to this role?
+1. Locate `keyword_tiers` in the job_description JSON.
+   - Tier 1 (tier1_must_have): prioritize projects that let you use these keywords authentically.
+   - Tier 2 (tier2_high_priority): surface these where the project context supports them.
+2. Which 2-3 projects most directly demonstrate skills required by this job description?
+3. For each selected project, which existing bullets can be rewritten to better surface Tier 1 keywords?
+4. What metrics or outcomes are implied but not stated? (e.g., "built for 1000 users" → "scaled to 1K users")
+5. Which projects should be excluded because they have no relevance to this role?
 </reasoning>
 
 <instructions>
@@ -214,9 +217,12 @@ Write the "skill_section" of a JSON resume for a candidate applying to the role 
 
 <reasoning>
 Before organizing skills:
-1. What are the Tier 1 technical skills in the job description (explicitly required)? Ensure these appear prominently.
+1. Locate `keyword_tiers` in the job_description JSON.
+   - Tier 1 (tier1_must_have): these MUST appear in the skill section. List them first in their category.
+   - Tier 2 (tier2_high_priority): include where the candidate genuinely has the skill.
+   - Tier 3 (tier3_bonus): omit from skills — they belong in cover letter/summary.
 2. What skill groupings make the most sense for this role? (e.g., an ML role: Languages / ML Frameworks / Cloud / Tools)
-3. Are there skills in the candidate's profile that are irrelevant noise for this specific role?
+3. Are there skills in the candidate's profile that are irrelevant noise for this specific role? Remove them.
 </reasoning>
 
 <instructions>
@@ -258,11 +264,14 @@ Write the "work_experience" section of a JSON resume for a candidate applying to
 
 <reasoning>
 Work through this analysis before writing:
-1. Which 2-3 work experiences are most relevant to this role? Which should be de-emphasized or omitted?
-2. For each selected experience, identify which original bullets already align with the JD and which need rewriting.
-3. What Tier 1 keywords from the JD can be woven into bullets truthfully based on what the candidate actually did?
+1. Locate `keyword_tiers` in the job_description JSON.
+   - Tier 1 (tier1_must_have): these MUST appear in at least one bullet per relevant experience.
+   - Tier 2 (tier2_high_priority): weave in where the candidate's work genuinely supports it.
+   - Tier 3 (tier3_bonus): use sparingly — only if it fits naturally.
+2. Which 2-3 work experiences are most relevant to this role? Which should be de-emphasized or omitted?
+3. For each selected experience, identify which original bullets already contain Tier 1 keywords and which need rewriting to include them.
 4. Where are the opportunities to add missing metrics (scale, speed, size, reduction, improvement)?
-5. Are there soft skills (leadership, cross-functional work, mentoring) the JD values that can be evidenced by existing work?
+5. Are there soft skills (leadership, cross-functional work, mentoring) the JD values (Tier 2) that can be evidenced by existing work?
 </reasoning>
 
 <instructions>

--- a/zlm/schemas/job_details_schema.py
+++ b/zlm/schemas/job_details_schema.py
@@ -11,10 +11,41 @@ Copyright (c) 2023-2024 Saurabh Zinjad. All rights reserved | https://github.com
 from typing import List
 from pydantic import BaseModel, Field
 
+
+class KeywordTiers(BaseModel):
+    """Keywords from a job description classified by priority for resume tailoring."""
+
+    tier1_must_have: List[str] = Field(
+        description=(
+            "Hard skills, specific tools, technologies, and certifications explicitly listed "
+            "as required. These MUST appear in the tailored resume. 4-5 keywords."
+        )
+    )
+    tier2_high_priority: List[str] = Field(
+        description=(
+            "Soft skills, experience types, and methodologies listed as preferred or strongly "
+            "desired. Include where the candidate's background genuinely supports them. 3-4 keywords."
+        )
+    )
+    tier3_bonus: List[str] = Field(
+        description=(
+            "Company culture language, nice-to-haves, and industry-specific terminology. "
+            "Weave into the cover letter and summary where authentic. 2-3 keywords."
+        )
+    )
+
+
 class JobDetails(BaseModel):
     job_title: str = Field(description="The specific role, its level, and scope within the organization.")
     job_purpose: str = Field(description="A high-level overview of the role and why it exists in the organization.")
-    keywords: List[str] = Field(description="Key expertise, skills, and requirements the job demands.")
+    keywords: List[str] = Field(description="All key expertise, skills, and requirements the job demands (flat list).")
+    keyword_tiers: KeywordTiers = Field(
+        description=(
+            "Keywords classified into three priority tiers for precise resume tailoring. "
+            "Tier 1 = must-have hard skills, Tier 2 = preferred soft skills/methodologies, "
+            "Tier 3 = culture/bonus language."
+        )
+    )
     job_duties_and_responsibilities: List[str] = Field(description="Focus on essential functions, their frequency and importance, level of decision-making, areas of accountability, and any supervisory responsibilities.")
     required_qualifications: List[str] = Field(description="Including education, minimum experience, specific knowledge, skills, abilities, and any required licenses or certifications.")
     preferred_qualifications: List[str] = Field(description="Additional \"nice-to-have\" qualifications that could set a candidate apart.")


### PR DESCRIPTION
## Summary

Classifies job description keywords into three priority tiers at extraction time and propagates that structure to every section generation prompt, so bullet rewriting knows exactly which keywords are must-have vs. optional vs. cultural.

Closes #54

---

## Problem

The flat `keywords` list gave every keyword equal weight. The LLM had no signal to distinguish `"Python" (required)` from `"customer-obsessed" (culture)`, so it either over-indexed on culture words or under-prioritized hard skills in bullets.

---

## Tier Definitions

| Tier | Field | Contents | Resume usage |
|------|-------|----------|-------------|
| **1** | `tier1_must_have` | Hard skills, tools, certifications explicitly required | **Must appear** in experience/skills bullets |
| **2** | `tier2_high_priority` | Soft skills, methodologies, preferred experience | Include where candidate's background genuinely supports |
| **3** | `tier3_bonus` | Culture language, nice-to-haves, domain jargon | Cover letter / summary only — omit from bullets |

---

## Changes

### `zlm/schemas/job_details_schema.py`
- New `KeywordTiers` Pydantic model (3 fields, detailed descriptions)
- `keyword_tiers: KeywordTiers` added to `JobDetails`
- Existing flat `keywords` field retained for backward compatibility

### `zlm/prompts/resume_prompt.py`
- `JOB_DETAILS_EXTRACTOR` `<instructions>` extended to request both fields with per-tier guidance (target counts, exact-terminology rule)

### `zlm/prompts/sections_prompt.py`
- **EXPERIENCE**: step 1 of `<reasoning>` now locates `keyword_tiers` in the job JSON and applies tier-aware bullet strategy
- **PROJECTS**: same tier-aware step; project selection prioritizes Tier 1 coverage
- **SKILLS**: step 1 references `keyword_tiers`; Tier 1 listed first per category; Tier 3 excluded

---

## Zero extra cost

`keyword_tiers` is extracted inside the existing `job_details_extraction` LLM call — no new method, no new API call. Because section prompts already receive `json.dumps(job_details)`, the tiers are automatically visible at every section generation step.

## Verified

All 9 prompt templates smoke-tested. `KeywordTiers` + `JobDetails` schema validated with a sample payload.