### PR TITLE
feat: implement causal chain bullet rewriting with seniority-aware framing

### DIFF
--- a/zlm/prompts/resume_prompt.py
+++ b/zlm/prompts/resume_prompt.py
@@ -47,7 +47,9 @@ Extract structured job details from the job description below. Focus on informat
 
 <reasoning>
 Think step by step before producing the final output:
-1. What is the core role and seniority level?
+1. What is the core role and seniority level? Look for signals: years of experience required,
+   title modifiers (Senior, Lead, Principal, Staff), scope of ownership, people management,
+   IC vs. managerial track. Map to one of: junior / mid / senior / lead.
 2. What are the must-have technical skills (Tier 1 — appear multiple times or listed as required)?
 3. What are the nice-to-have skills (Tier 2 — mentioned once or listed as preferred)?
 4. What implicit keywords does the company culture suggest (Tier 3 — values, methodologies, domain terms)?
@@ -61,6 +63,10 @@ Think step by step before producing the final output:
     • Tier 2 (tier2_high_priority): Soft skills, methodologies, experience types listed as preferred.
       Aim for 3-4 items.
     • Tier 3 (tier3_bonus): Culture language, nice-to-haves, domain jargon. Aim for 2-3 items.
+- Set `seniority_level` to one of: junior / mid / senior / lead.
+  Use these signals: years required (0-2 → junior, 2-5 → mid, 5+ → senior),
+  title prefix (Senior/Staff/Principal → senior, Lead/Manager/Director → lead),
+  scope language ("owns", "drives", "leads team" → senior/lead).
 - Preserve exact JD terminology in all keyword fields (e.g., "PostgreSQL" not "SQL database").
 - If salary, location, or company details are absent, use null rather than guessing.
 </instructions>"""

--- a/zlm/prompts/sections_prompt.py
+++ b/zlm/prompts/sections_prompt.py
@@ -178,12 +178,20 @@ Work through this analysis before writing:
 </reasoning>
 
 <instructions>
-- Select 2-3 most relevant projects. Drop irrelevant ones.
-- Each project: 2-3 bullet points using Action + Skill + Metric format.
-- Weave in job description keywords naturally — never keyword-stuff.
-- Quantify every bullet where possible. If no metric exists, add scale/context.
-- Do not fabricate project details, links, or outcomes.
-- Dates: "Mon YYYY" format.
+Bullet formula (apply to every bullet without exception):
+  [Strong Action Verb] + [Tier 1 Keyword / Relevant Skill] + [Quantified Impact or Scope]
+
+Rules:
+1. Prioritize projects that let Tier 1 keywords appear authentically in bullets.
+2. Every bullet MUST contain at least one Tier 1 keyword naturally.
+3. Metrics first — use numbers wherever original data supports them.
+4. Scope fallback — if no metric, include: user count, data scale, latency, or team size.
+5. NEVER fabricate project details, links, or outcomes.
+6. Seniority framing — locate `seniority_level` in job_description JSON:
+   - junior/mid : emphasize technical implementation, learning, and concrete outputs.
+   - senior/lead: emphasize architectural decisions, cross-team impact, and business outcomes.
+7. Select 2-3 most relevant projects. Drop anything with no relevance to the role.
+8. Dates: "Mon YYYY" format.
 </instructions>
 """ + _BULLET_EXAMPLES + """
 <output_schema>
@@ -195,8 +203,8 @@ Work through this analysis before writing:
     "from_date": "<Mon YYYY or null>",
     "to_date": "<Mon YYYY or null>",
     "description": [
-      "<bullet 1: Action + Skill + Metric>",
-      "<bullet 2: Action + Skill + Metric>"
+      "<bullet 1: Action + Tier1Keyword + Metric/Scope>",
+      "<bullet 2: Action + Tier1Keyword + Metric/Scope>"
     ]
   }}
 ]
@@ -275,13 +283,25 @@ Work through this analysis before writing:
 </reasoning>
 
 <instructions>
-- Include 2-3 most relevant experiences. Preserve all factual details (company, role, dates, location).
-- Each experience: 3 bullet points using Action + Skill + Metric format.
-- Start each bullet with a strong past-tense action verb.
-- Naturally incorporate Tier 1 job description keywords — no keyword stuffing.
-- Quantify every bullet (numbers, percentages, scale, time saved). If original has no metric, add reasonable context.
-- Do not change job titles, companies, or dates. Do not fabricate outcomes.
-- Order experiences reverse-chronologically.
+Bullet formula (apply to every bullet without exception):
+  [Strong Action Verb] + [Tier 1 Keyword / Relevant Skill] + [Quantified Impact or Scope]
+
+Rules:
+1. Every bullet MUST contain at least one Tier 1 keyword from `keyword_tiers.tier1_must_have` —
+   woven in naturally, not bolted on.
+2. Metrics first — use numbers, percentages, time saved, or error rates whenever the original
+   resume data supports them.
+3. Scope fallback — if no specific metric exists, include scope: team size, data volume,
+   user count, system scale, or time to delivery.
+4. NEVER fabricate metrics or outcomes not supported by the original resume data.
+5. Seniority framing — locate `seniority_level` in the job_description JSON and frame bullets accordingly:
+   - junior : emphasize learning velocity, initiative, direct contribution, and collaboration.
+   - mid    : emphasize technical wins, measurable outcomes, and independent ownership.
+   - senior : emphasize system-level scope, cross-team impact, and strategic decisions.
+   - lead   : emphasize people leadership, org-level outcomes, and directional influence.
+6. Select 2-3 most relevant experiences. Preserve all factual details (company, role, dates, location).
+   Do not change job titles, companies, or dates.
+7. Order experiences reverse-chronologically.
 </instructions>
 """ + _BULLET_EXAMPLES + """
 <output_schema>
@@ -293,9 +313,9 @@ Work through this analysis before writing:
     "from_date": "<Mon YYYY>",
     "to_date": "<Mon YYYY or Present>",
     "description": [
-      "<bullet 1: Action + Skill + Metric>",
-      "<bullet 2: Action + Skill + Metric>",
-      "<bullet 3: Action + Skill + Metric>"
+      "<bullet 1: Action + Tier1Keyword + Metric/Scope>",
+      "<bullet 2: Action + Tier1Keyword + Metric/Scope>",
+      "<bullet 3: Action + Tier1/Tier2Keyword + Metric/Scope>"
     ]
   }}
 ]

--- a/zlm/schemas/job_details_schema.py
+++ b/zlm/schemas/job_details_schema.py
@@ -8,7 +8,7 @@ Copyright (c) 2023-2024 Saurabh Zinjad. All rights reserved | https://github.com
 -----------------------------------------------------------------------
 '''
 
-from typing import List
+from typing import List, Literal
 from pydantic import BaseModel, Field
 
 
@@ -44,6 +44,15 @@ class JobDetails(BaseModel):
             "Keywords classified into three priority tiers for precise resume tailoring. "
             "Tier 1 = must-have hard skills, Tier 2 = preferred soft skills/methodologies, "
             "Tier 3 = culture/bonus language."
+        )
+    )
+    seniority_level: Literal["junior", "mid", "senior", "lead"] = Field(
+        description=(
+            "Seniority level of the target role inferred from the job description. "
+            "'junior' = 0-2 years, IC learning role; "
+            "'mid' = 2-5 years, independent contributor; "
+            "'senior' = 5+ years, owns outcomes; "
+            "'lead' = people/tech leadership, org-level impact."
         )
     )
     job_duties_and_responsibilities: List[str] = Field(description="Focus on essential functions, their frequency and importance, level of decision-making, areas of accountability, and any supervisory responsibilities.")


### PR DESCRIPTION
## Summary

Enforces an explicit causal chain formula on every resume bullet, anchors Tier 1 keywords from #54, and adjusts framing based on the detected seniority level of the target role.

Closes #55
Depends on #54 ✅

---

## Problem

| Issue | Impact |
|-------|--------|
| No enforced bullet structure | Bullets ranged from excellent to generic with no consistency |
| No Tier 1 keyword obligation | Keywords extracted in #54 weren't guaranteed to appear in bullets |
| No seniority awareness | Same framing for a junior analyst and a staff engineer |
| No fabrication guard | LLM could invent metrics not supported by the candidate's history |

---

## Causal Chain Formula



**Bad:** "Worked on database migration projects"
**Good:** "Led 6-engineer team migrating 14M records to PostgreSQL, cutting query latency by 68%"

---

## Rules (applied to every bullet in EXPERIENCE + PROJECTS)

| # | Rule |
|---|------|
| 1 | Every bullet must contain ≥1 **Tier 1** keyword from  |
| 2 | Use numbers/percentages whenever the original resume data supports them |
| 3 | Scope fallback: team size, data volume, user count if no metric exists |
| 4 | **Never fabricate** metrics not in the original resume |
| 5 | Seniority framing — see table below |
| 6 | Preserve all factual details (company, title, dates) exactly |
| 7 | Reverse-chronological order |

### Seniority framing

|  | Bullet emphasis |
|-------------------|----------------|
|  | Learning velocity, initiative, direct contribution, collaboration |
|  | Technical wins, measurable outcomes, independent ownership |
|  | System-level scope, cross-team impact, strategic decisions |
|  | People leadership, org-level outcomes, directional influence |

---

## Schema change

Added  to .

Detection signals baked into :
- Years required: 0-2 → junior, 2-5 → mid, 5+ → senior
- Title modifiers: Senior/Staff/Principal → senior, Lead/Manager/Director → lead
- Scope language: "owns", "drives", "leads team" → senior/lead

## Zero integration cost

 flows into section prompts via the existing  — no changes to .

## Verified

All 9 templates smoke-tested. Literal constraint validated (rejects invalid values).